### PR TITLE
SNAPSHOT is not available anymore

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [instaparse "1.4.10-SNAPSHOT"]]
+                 [instaparse "1.4.10"]]
   :main instaparse.demo
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
`lein uberjar` without the change doesn't work

There is another issue, but that's probably related to the (new) clojure version